### PR TITLE
Fix: set cancel-in-progress to true to avoid stuck deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration, specifically adjusting how concurrent deployments are managed.

* Set `cancel-in-progress` to `true` in the `concurrency` section of `.github/workflows/deploy.yml`, ensuring that any in-progress deployment jobs are cancelled when a new deployment is triggered.