### PR TITLE
feat: animated portfolio dossier landing page

### DIFF
--- a/.groupcode/codegroups.json
+++ b/.groupcode/codegroups.json
@@ -228,5 +228,111 @@
       "filePath": "src/App.js",
       "lineNumbers": "18-38"
     }
+  ],
+  "tsx": [
+    {
+      "functionality": "motion",
+      "description": "Stagger delay helper for scroll-reveal sequencing",
+      "filePath": "src/pages/PortfolioDossier.tsx",
+      "lineNumbers": "4-7"
+    },
+    {
+      "functionality": "types",
+      "description": "Portfolio dossier data contracts",
+      "filePath": "src/pages/PortfolioDossier.tsx",
+      "lineNumbers": "8-68"
+    },
+    {
+      "functionality": "content",
+      "description": "Curated content for the redesigned portfolio",
+      "filePath": "src/pages/PortfolioDossier.tsx",
+      "lineNumbers": "69-346"
+    },
+    {
+      "functionality": "portfoliodossier",
+      "description": "New root portfolio page",
+      "filePath": "src/pages/PortfolioDossier.tsx",
+      "lineNumbers": "347-350"
+    },
+    {
+      "functionality": "motion",
+      "description": "Scroll-reveal, stat count-up, and read-progress wiring",
+      "filePath": "src/pages/PortfolioDossier.tsx",
+      "lineNumbers": "351-667"
+    }
+  ],
+  "css": [
+    {
+      "functionality": "theme",
+      "description": "Portfolio dossier design tokens",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "1-16"
+    },
+    {
+      "functionality": "base",
+      "description": "Page shell and global dossier behavior",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "18-29"
+    },
+    {
+      "functionality": "hero",
+      "description": "First viewport with real profile image and console signature",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "42-54"
+    },
+    {
+      "functionality": "proof",
+      "description": "Outcome strip below hero",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "284-290"
+    },
+    {
+      "functionality": "sections",
+      "description": "Shared portfolio section layout",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "323-326"
+    },
+    {
+      "functionality": "cases",
+      "description": "Delivery record cards",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "360-364"
+    },
+    {
+      "functionality": "fieldnotes",
+      "description": "Visual project and speaking highlights",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "439-444"
+    },
+    {
+      "functionality": "capabilities",
+      "description": "Skill groups",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "522-527"
+    },
+    {
+      "functionality": "tools",
+      "description": "Published package and extension registry section",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "568-571"
+    },
+    {
+      "functionality": "credentials",
+      "description": "Certifications, teaching, and education from CV",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "645-648"
+    },
+    {
+      "functionality": "contact",
+      "description": "Final call to action",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "712-721"
+    },
+    {
+      "functionality": "responsive",
+      "description": "Tablet and mobile refinements",
+      "filePath": "src/pages/PortfolioDossier.css",
+      "lineNumbers": "773-782"
+    }
   ]
 }

--- a/.groupcode/functionalities.json
+++ b/.groupcode/functionalities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.3.0",
-  "totalFunctionalities": 36,
+  "totalFunctionalities": 52,
   "functionalities": {
     "authentication": {
       "level": 1,
@@ -341,6 +341,150 @@
       "groupCount": 1,
       "fileTypes": [
         "js"
+      ]
+    },
+    "motion": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 2,
+      "fileTypes": [
+        "tsx"
+      ]
+    },
+    "types": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "tsx"
+      ]
+    },
+    "content": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "tsx"
+      ]
+    },
+    "portfoliodossier": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "tsx"
+      ]
+    },
+    "theme": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "base": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "hero": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "proof": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "sections": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "cases": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "fieldnotes": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "capabilities": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "tools": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "credentials": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "contact": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
+      ]
+    },
+    "responsive": {
+      "level": 1,
+      "parent": null,
+      "children": [],
+      "groupCount": 1,
+      "fileTypes": [
+        "css"
       ]
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,13 @@ import HomePage from './pages/HomePage'
 import PortfolioPage from './pages/PortfolioPage'
 import GroupCode from './pages/GroupCode'
 import TerminalPortfolio from './pages/TerminalPortfolio'
+import PortfolioDossier from './pages/PortfolioDossier'
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<TerminalPortfolio />} />
+      <Route path="/" element={<PortfolioDossier />} />
+      <Route path="/terminal" element={<TerminalPortfolio />} />
       <Route path="/classic" element={<HomePage />} />
       <Route path="/portfolio" element={<PortfolioPage />} />
       <Route path="/groupcode" element={<GroupCode />} />

--- a/src/pages/PortfolioDossier.css
+++ b/src/pages/PortfolioDossier.css
@@ -1,0 +1,1082 @@
+/* @group Theme : Portfolio dossier design tokens */
+:root {
+  --dossier-ink: #17130f;
+  --dossier-paper: #f7f4ec;
+  --dossier-panel: #fffaf0;
+  --dossier-cloud: #1768ac;
+  --dossier-copper: #bd6f36;
+  --dossier-green: #1f9d72;
+  --dossier-plum: #7254a6;
+  --dossier-muted: #675f56;
+  --dossier-line: rgba(23, 19, 15, 0.16);
+  --dossier-shadow: 0 24px 80px rgba(23, 19, 15, 0.16);
+  --dossier-display: "Arial Narrow", "Bahnschrift Condensed", "Segoe UI", sans-serif;
+  --dossier-body: "Inter", "Segoe UI", system-ui, sans-serif;
+  --dossier-mono: "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+}
+
+/* @group Base : Page shell and global dossier behavior */
+.dossier-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(90deg, rgba(23, 19, 15, 0.05) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(23, 19, 15, 0.04) 1px, transparent 1px),
+    var(--dossier-paper);
+  background-size: 42px 42px;
+  color: var(--dossier-ink);
+  font-family: var(--dossier-body);
+  overflow-x: hidden;
+}
+
+.dossier-shell a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.dossier-shell a:focus-visible,
+.dossier-shell button:focus-visible {
+  outline: 3px solid var(--dossier-copper);
+  outline-offset: 4px;
+}
+
+/* @group Hero : First viewport with real profile image and console signature */
+.dossier-hero {
+  min-height: min(820px, 86vh);
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  padding: 24px clamp(20px, 5vw, 72px) 48px;
+  background:
+    linear-gradient(90deg, rgba(247, 244, 236, 0.96) 0%, rgba(247, 244, 236, 0.9) 45%, rgba(247, 244, 236, 0.22) 76%),
+    url("/assets/img/hero-bg.jpg") right center / contain no-repeat,
+    var(--dossier-paper);
+}
+
+.dossier-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 12px;
+  background:
+    linear-gradient(90deg, var(--dossier-cloud) 0 28%, var(--dossier-green) 28% 48%, var(--dossier-copper) 48% 72%, var(--dossier-plum) 72% 100%);
+  z-index: -1;
+}
+
+.dossier-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  position: relative;
+  z-index: 2;
+}
+
+.dossier-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--dossier-mono);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.dossier-brand-mark {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--dossier-ink);
+  color: var(--dossier-paper);
+  border-radius: 6px;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), background 0.35s ease;
+}
+
+.dossier-brand:hover .dossier-brand-mark {
+  transform: rotate(-6deg) scale(1.08);
+  background: var(--dossier-cloud);
+}
+
+.dossier-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px;
+  border: 1px solid var(--dossier-line);
+  background: rgba(255, 250, 240, 0.8);
+  backdrop-filter: blur(12px);
+}
+
+.dossier-nav-links a {
+  padding: 10px 14px;
+  border-radius: 5px;
+  color: var(--dossier-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+
+.dossier-nav-links a:active {
+  transform: translateY(1px);
+}
+
+.dossier-nav-links a:hover {
+  background: var(--dossier-ink);
+  color: var(--dossier-paper);
+}
+
+.dossier-hero-content {
+  width: min(760px, 100%);
+  align-self: center;
+  padding: 54px 0 104px;
+}
+
+.dossier-kicker,
+.dossier-section-heading p,
+.dossier-contact p {
+  margin: 0 0 14px;
+  color: var(--dossier-cloud);
+  font-family: var(--dossier-mono);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dossier-hero h1 {
+  max-width: 860px;
+  margin: 0;
+  color: var(--dossier-ink);
+  font-family: var(--dossier-display);
+  font-size: clamp(3.2rem, 6.2vw, 5.95rem);
+  font-stretch: condensed;
+  font-weight: 900;
+  line-height: 0.9;
+  text-transform: uppercase;
+}
+
+.dossier-manifesto {
+  max-width: 680px;
+  margin: 18px 0 0;
+  color: var(--dossier-copper);
+  font-family: var(--dossier-display);
+  font-size: clamp(2.1rem, 4.2vw, 3.75rem);
+  font-weight: 900;
+  line-height: 0.94;
+  text-transform: uppercase;
+}
+
+.dossier-hero-copy {
+  max-width: 620px;
+  margin: 22px 0 0;
+  color: #312b25;
+  font-size: clamp(1.06rem, 2vw, 1.3rem);
+  line-height: 1.65;
+}
+
+.dossier-actions,
+.dossier-contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 34px;
+}
+
+.dossier-action,
+.dossier-contact-actions a {
+  min-height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border: 1px solid var(--dossier-line);
+  border-radius: 6px;
+  background: rgba(255, 250, 240, 0.84);
+  color: var(--dossier-ink);
+  font-weight: 800;
+  box-shadow: 0 10px 28px rgba(23, 19, 15, 0.08);
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.dossier-action.primary {
+  background: var(--dossier-ink);
+  color: var(--dossier-paper);
+}
+
+.dossier-action.icon-only {
+  width: 46px;
+  padding: 0;
+}
+
+.dossier-action:hover,
+.dossier-contact-actions a:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(23, 19, 15, 0.14);
+}
+
+.dossier-console {
+  position: absolute;
+  right: clamp(20px, 5vw, 72px);
+  bottom: 52px;
+  width: min(480px, calc(100% - 40px));
+  border: 1px solid rgba(247, 244, 236, 0.22);
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(23, 19, 15, 0.9);
+  color: #f7f4ec;
+  box-shadow: var(--dossier-shadow);
+}
+
+.dossier-console-top {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  background: rgba(255, 250, 240, 0.08);
+  font-family: var(--dossier-mono);
+  font-size: 0.78rem;
+}
+
+.dossier-console-top span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--dossier-copper);
+}
+
+.dossier-console-top span:nth-child(2) {
+  background: #e0ad3d;
+}
+
+.dossier-console-top span:nth-child(3) {
+  background: var(--dossier-green);
+}
+
+.dossier-console-top strong {
+  margin-left: 8px;
+  color: rgba(247, 244, 236, 0.76);
+  font-weight: 700;
+}
+
+.dossier-console-body {
+  padding: 18px;
+  font-family: var(--dossier-mono);
+  font-size: 0.88rem;
+}
+
+.dossier-console-body p {
+  margin: 0 0 10px;
+}
+
+.dossier-console-body p span {
+  color: var(--dossier-green);
+}
+
+.dossier-console-ready {
+  padding-top: 10px;
+  border-top: 1px solid rgba(247, 244, 236, 0.18);
+  color: rgba(247, 244, 236, 0.78);
+}
+
+/* @group Proof : Outcome strip below hero */
+.dossier-proof {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-bottom: 1px solid var(--dossier-line);
+  background: var(--dossier-panel);
+}
+
+.dossier-proof-item {
+  min-height: 178px;
+  padding: 28px clamp(20px, 4vw, 44px);
+  border-right: 1px solid var(--dossier-line);
+}
+
+.dossier-proof-item:last-child {
+  border-right: 0;
+}
+
+.dossier-proof-item strong {
+  display: block;
+  color: var(--dossier-copper);
+  font-family: var(--dossier-display);
+  font-size: clamp(3rem, 7vw, 5rem);
+  line-height: 0.9;
+}
+
+.dossier-proof-item span {
+  display: block;
+  margin-top: 10px;
+  font-weight: 900;
+}
+
+.dossier-proof-item p {
+  max-width: 250px;
+  margin: 10px 0 0;
+  color: var(--dossier-muted);
+  line-height: 1.5;
+}
+
+/* @group Sections : Shared portfolio section layout */
+.dossier-section {
+  padding: clamp(64px, 9vw, 124px) clamp(20px, 5vw, 72px);
+}
+
+.dossier-split {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.76fr) minmax(0, 1.24fr);
+  gap: clamp(32px, 6vw, 88px);
+  align-items: start;
+}
+
+.dossier-section-heading {
+  position: sticky;
+  top: 32px;
+}
+
+.dossier-section-heading.compact {
+  max-width: 760px;
+  position: static;
+  margin-bottom: 32px;
+}
+
+.dossier-section-heading h2,
+.dossier-contact h2 {
+  margin: 0;
+  font-family: var(--dossier-display);
+  font-size: clamp(2.5rem, 6vw, 5.8rem);
+  font-weight: 900;
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.dossier-split .dossier-section-heading h2 {
+  font-size: clamp(2.4rem, 4.8vw, 4.65rem);
+}
+
+/* @group Cases : Delivery record cards */
+.dossier-case-list {
+  display: grid;
+  gap: 18px;
+}
+
+.dossier-case {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.72fr);
+  gap: 24px;
+  padding: clamp(22px, 4vw, 34px);
+  border: 1px solid var(--dossier-line);
+  border-radius: 8px;
+  background: rgba(255, 250, 240, 0.76);
+  box-shadow: 0 12px 40px rgba(23, 19, 15, 0.08);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.dossier-case:hover {
+  transform: translateY(-3px);
+  border-color: rgba(23, 19, 15, 0.3);
+  box-shadow: 0 20px 52px rgba(23, 19, 15, 0.14);
+}
+
+.dossier-case h3,
+.dossier-field-note h3,
+.dossier-capability h3,
+.dossier-credential-panel h3 {
+  margin: 0;
+  color: var(--dossier-ink);
+  font-size: 1.2rem;
+  line-height: 1.25;
+}
+
+.dossier-case-period {
+  display: inline-flex;
+  margin-bottom: 12px;
+  color: var(--dossier-cloud);
+  font-family: var(--dossier-mono);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dossier-case p {
+  margin: 12px 0 0;
+  color: var(--dossier-muted);
+  line-height: 1.62;
+}
+
+.dossier-case strong {
+  color: #271f19;
+  font-size: 1rem;
+  line-height: 1.52;
+}
+
+.dossier-tags {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dossier-tags span,
+.dossier-capability li {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 1px solid rgba(23, 19, 15, 0.14);
+  border-radius: 5px;
+  background: rgba(23, 19, 15, 0.05);
+  color: var(--dossier-muted);
+  font-family: var(--dossier-mono);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+/* @group FieldNotes : Visual project and speaking highlights */
+.dossier-field-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr 0.9fr;
+  gap: 18px;
+}
+
+.dossier-field-note {
+  min-height: 440px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  border-radius: 8px;
+  background: var(--dossier-ink);
+  box-shadow: var(--dossier-shadow);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.45s ease;
+}
+
+.dossier-field-note:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 90px rgba(23, 19, 15, 0.28);
+}
+
+.dossier-field-note div {
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dossier-field-note:hover div {
+  transform: translateY(-4px);
+}
+
+.dossier-field-note:first-child {
+  min-height: 520px;
+}
+
+.dossier-field-note img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.45s ease;
+}
+
+.dossier-field-note::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(23, 19, 15, 0.08), rgba(23, 19, 15, 0.86));
+}
+
+.dossier-field-note:hover img {
+  transform: scale(1.04);
+}
+
+.dossier-field-note div {
+  position: relative;
+  z-index: 1;
+  padding: 24px;
+  color: var(--dossier-paper);
+}
+
+.dossier-field-note span {
+  display: inline-flex;
+  margin-bottom: 12px;
+  color: #f5c16c;
+  font-family: var(--dossier-mono);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.dossier-field-note h3 {
+  color: var(--dossier-paper);
+  font-size: clamp(1.25rem, 2vw, 1.8rem);
+}
+
+.dossier-field-note p {
+  margin: 10px 0 0;
+  color: rgba(247, 244, 236, 0.78);
+}
+
+/* @group Capabilities : Skill groups */
+.dossier-capabilities {
+  background: #efe7d8;
+  border-top: 1px solid var(--dossier-line);
+  border-bottom: 1px solid var(--dossier-line);
+}
+
+.dossier-capability-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.dossier-capability {
+  padding: 28px;
+  border: 1px solid rgba(23, 19, 15, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 250, 240, 0.7);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.dossier-capability:hover {
+  transform: translateY(-3px);
+  border-color: rgba(23, 19, 15, 0.28);
+  box-shadow: 0 16px 44px rgba(23, 19, 15, 0.12);
+}
+
+.dossier-capability li {
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+
+.dossier-capability li:hover {
+  background: var(--dossier-ink);
+  color: var(--dossier-paper);
+  transform: translateY(-2px);
+}
+
+.dossier-capability ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* @group Tools : Published package and extension registry section */
+.dossier-tools {
+  background: #fbf6ea;
+}
+
+.dossier-registry-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
+.dossier-registry-card,
+.dossier-artifact {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--dossier-line);
+  border-radius: 8px;
+  background: rgba(255, 250, 240, 0.78);
+  box-shadow: 0 12px 40px rgba(23, 19, 15, 0.08);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.dossier-registry-card {
+  min-height: 210px;
+  padding: 22px;
+}
+
+.dossier-registry-card span,
+.dossier-artifact span {
+  color: var(--dossier-cloud);
+  font-family: var(--dossier-mono);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dossier-registry-card strong {
+  color: var(--dossier-copper);
+  font-family: var(--dossier-display);
+  font-size: clamp(2.1rem, 3.4vw, 3.6rem);
+  line-height: 0.9;
+  text-transform: uppercase;
+}
+
+.dossier-registry-card p,
+.dossier-artifact p {
+  margin: 0;
+  color: var(--dossier-muted);
+  line-height: 1.5;
+}
+
+.dossier-registry-card:hover,
+.dossier-artifact:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 48px rgba(23, 19, 15, 0.13);
+}
+
+.dossier-artifact-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.dossier-artifact {
+  min-height: 180px;
+  align-content: start;
+  padding: 22px;
+}
+
+.dossier-artifact strong {
+  color: var(--dossier-ink);
+  font-size: 1.08rem;
+  line-height: 1.25;
+}
+
+/* @group Credentials : Certifications, teaching, and education from CV */
+.dossier-credentials {
+  background: var(--dossier-paper);
+}
+
+.dossier-credential-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 0.9fr);
+  gap: 18px;
+}
+
+.dossier-credential-panel {
+  padding: 28px;
+  border: 1px solid var(--dossier-line);
+  border-radius: 8px;
+  background: rgba(255, 250, 240, 0.78);
+  box-shadow: 0 12px 40px rgba(23, 19, 15, 0.08);
+}
+
+.dossier-credential-list,
+.dossier-timeline {
+  display: grid;
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.dossier-credential-list a,
+.dossier-credential-list div,
+.dossier-timeline div {
+  display: grid;
+  gap: 5px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(23, 19, 15, 0.12);
+}
+
+.dossier-credential-list a {
+  transition: transform 0.25s ease, color 0.25s ease;
+}
+
+.dossier-credential-list a:hover {
+  transform: translateX(4px);
+}
+
+.dossier-credential-list a:hover strong {
+  color: var(--dossier-cloud);
+}
+
+.dossier-credential-list strong,
+.dossier-timeline strong {
+  color: var(--dossier-ink);
+  line-height: 1.32;
+}
+
+.dossier-credential-list span,
+.dossier-timeline span {
+  color: var(--dossier-copper);
+  font-family: var(--dossier-mono);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.dossier-timeline p {
+  margin: 3px 0 0;
+  color: var(--dossier-muted);
+  line-height: 1.55;
+}
+
+/* @group Contact : Final call to action */
+.dossier-contact {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 28px;
+  align-items: center;
+  padding: clamp(56px, 8vw, 96px) clamp(20px, 5vw, 72px);
+  background: var(--dossier-ink);
+  color: var(--dossier-paper);
+}
+
+.dossier-contact p {
+  color: #f5c16c;
+}
+
+.dossier-contact h2 {
+  max-width: 880px;
+  color: var(--dossier-paper);
+}
+
+.dossier-contact-actions {
+  justify-content: flex-end;
+  margin-top: 0;
+}
+
+.dossier-contact-actions a {
+  background: rgba(247, 244, 236, 0.08);
+  color: var(--dossier-paper);
+  border-color: rgba(247, 244, 236, 0.2);
+}
+
+.dossier-profile-grid {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.dossier-profile-grid a {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(247, 244, 236, 0.16);
+  border-radius: 6px;
+  background: rgba(247, 244, 236, 0.06);
+  color: rgba(247, 244, 236, 0.88);
+  font-weight: 800;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, border-color 0.25s ease;
+}
+
+.dossier-profile-grid a:hover {
+  background: rgba(247, 244, 236, 0.14);
+  color: var(--dossier-paper);
+  border-color: rgba(247, 244, 236, 0.4);
+  transform: translateY(-2px);
+}
+
+/* @group Motion : Read progress, scroll reveals, and entrance choreography */
+.dossier-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  transform: scaleX(0);
+  transform-origin: left center;
+  background: linear-gradient(90deg, var(--dossier-cloud), var(--dossier-green) 38%, var(--dossier-copper) 68%, var(--dossier-plum));
+  z-index: 50;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    transform: translateY(28px);
+    transition:
+      opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+      transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+    transition-delay: var(--reveal-delay, 0s);
+    will-change: opacity, transform;
+  }
+
+  .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+  }
+
+  @keyframes dossier-rise {
+    from {
+      opacity: 0;
+      transform: translateY(26px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .dossier-hero-content > * {
+    animation: dossier-rise 0.85s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+  }
+
+  .dossier-hero-content > .dossier-kicker {
+    animation-delay: 0.05s;
+  }
+  .dossier-hero-content > h1 {
+    animation-delay: 0.16s;
+  }
+  .dossier-hero-content > .dossier-manifesto {
+    animation-delay: 0.3s;
+  }
+  .dossier-hero-content > .dossier-hero-copy {
+    animation-delay: 0.44s;
+  }
+  .dossier-hero-content > .dossier-actions {
+    animation-delay: 0.58s;
+  }
+
+  @keyframes dossier-console-in {
+    from {
+      opacity: 0;
+      transform: translateY(32px) scale(0.985);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .dossier-console {
+    animation: dossier-console-in 0.9s cubic-bezier(0.22, 1, 0.36, 1) 0.45s backwards;
+  }
+
+  @keyframes dossier-line-in {
+    from {
+      opacity: 0;
+      transform: translateX(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .dossier-console-body p {
+    animation: dossier-line-in 0.5s ease backwards;
+  }
+
+  .dossier-console-body p:nth-child(1) {
+    animation-delay: 0.85s;
+  }
+  .dossier-console-body p:nth-child(2) {
+    animation-delay: 1.02s;
+  }
+  .dossier-console-body p:nth-child(3) {
+    animation-delay: 1.19s;
+  }
+  .dossier-console-body p:nth-child(4) {
+    animation-delay: 1.36s;
+  }
+  .dossier-console-body p:nth-child(5) {
+    animation-delay: 1.53s;
+  }
+  .dossier-console-body p:nth-child(6) {
+    animation-delay: 1.7s;
+  }
+
+  .dossier-console-ready::after {
+    content: "▋";
+    display: inline-block;
+    margin-left: 4px;
+    color: var(--dossier-green);
+    animation: dossier-blink 1.05s steps(1, end) infinite;
+    animation-delay: 2s;
+  }
+
+  @keyframes dossier-blink {
+    0%,
+    50% {
+      opacity: 1;
+    }
+    50.01%,
+    100% {
+      opacity: 0;
+    }
+  }
+}
+
+/* @group Responsive : Tablet and mobile refinements */
+@media (max-width: 980px) {
+  .dossier-hero {
+    min-height: auto;
+    padding-bottom: 300px;
+    background:
+      linear-gradient(180deg, rgba(247, 244, 236, 0.98) 0%, rgba(247, 244, 236, 0.92) 54%, rgba(247, 244, 236, 0.18) 100%),
+      url("/assets/img/hero-bg.jpg") right bottom / 82% auto no-repeat,
+      var(--dossier-paper);
+  }
+
+  .dossier-hero-content {
+    padding: 46px 0 40px;
+  }
+
+  .dossier-console {
+    left: 20px;
+    right: 20px;
+    bottom: 42px;
+    width: auto;
+  }
+
+  .dossier-proof,
+  .dossier-capability-grid,
+  .dossier-registry-grid,
+  .dossier-artifact-grid,
+  .dossier-credential-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dossier-split,
+  .dossier-contact {
+    grid-template-columns: 1fr;
+  }
+
+  .dossier-section-heading {
+    position: static;
+  }
+
+  .dossier-field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dossier-field-note,
+  .dossier-field-note:first-child {
+    min-height: 360px;
+  }
+
+  .dossier-contact-actions {
+    justify-content: flex-start;
+  }
+
+  .dossier-profile-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .dossier-hero {
+    padding: 18px 16px 42px;
+    background:
+      linear-gradient(180deg, rgba(247, 244, 236, 0.99) 0%, rgba(247, 244, 236, 0.94) 62%, rgba(247, 244, 236, 0.18) 100%),
+      url("/assets/img/hero-bg.jpg") center bottom / 112% auto no-repeat,
+      var(--dossier-paper);
+  }
+
+  .dossier-nav {
+    align-items: center;
+    gap: 12px;
+  }
+
+  .dossier-nav-links {
+    width: 100%;
+    max-width: none;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .dossier-nav-links a {
+    padding: 8px 6px;
+    text-align: center;
+    font-size: 0.66rem;
+  }
+
+  .dossier-brand span:last-child {
+    display: none;
+  }
+
+  .dossier-hero h1 {
+    font-size: clamp(2.75rem, 12vw, 3.7rem);
+  }
+
+  .dossier-manifesto {
+    font-size: clamp(1.85rem, 8vw, 2.45rem);
+  }
+
+  .dossier-kicker {
+    margin-bottom: 10px;
+    font-size: 0.7rem;
+  }
+
+  .dossier-hero-copy {
+    margin-top: 16px;
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  .dossier-actions {
+    margin-top: 22px;
+    gap: 10px;
+  }
+
+  .dossier-action {
+    min-height: 44px;
+    padding: 10px 14px;
+  }
+
+  .dossier-actions,
+  .dossier-contact-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .dossier-action.icon-only {
+    width: 100%;
+  }
+
+  .dossier-console-body {
+    font-size: 0.78rem;
+  }
+
+  .dossier-console {
+    display: none;
+  }
+
+  .dossier-proof,
+  .dossier-capability-grid,
+  .dossier-registry-grid,
+  .dossier-artifact-grid,
+  .dossier-credential-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .dossier-proof-item {
+    border-right: 0;
+    border-bottom: 1px solid var(--dossier-line);
+  }
+
+  .dossier-case {
+    grid-template-columns: 1fr;
+  }
+
+  .dossier-section {
+    padding: 58px 16px;
+  }
+
+  .dossier-field-note,
+  .dossier-field-note:first-child {
+    min-height: 330px;
+  }
+
+  .dossier-contact {
+    padding: 54px 16px;
+  }
+
+  .dossier-profile-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dossier-shell *,
+  .dossier-shell *::before,
+  .dossier-shell *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/src/pages/PortfolioDossier.tsx
+++ b/src/pages/PortfolioDossier.tsx
@@ -1,0 +1,668 @@
+import { useEffect, useRef, type CSSProperties } from 'react'
+import './PortfolioDossier.css'
+
+// @group Motion : Stagger delay helper for scroll-reveal sequencing
+const stagger = (index: number): CSSProperties =>
+  ({ '--reveal-delay': `${index * 0.07}s` } as unknown as CSSProperties)
+
+// @group Types : Portfolio dossier data contracts
+interface ProofPoint {
+  value: string
+  label: string
+  detail: string
+}
+
+interface CaseStudy {
+  title: string
+  period: string
+  context: string
+  impact: string
+  stack: string[]
+}
+
+interface FieldNote {
+  title: string
+  meta: string
+  image: string
+  category: string
+}
+
+interface CapabilityGroup {
+  title: string
+  items: string[]
+}
+
+interface Credential {
+  title: string
+  issuer: string
+  meta: string
+  href?: string
+}
+
+interface TimelineEntry {
+  title: string
+  meta: string
+  detail: string
+}
+
+interface ProfileLink {
+  label: string
+  href: string
+  icon: string
+}
+
+interface RegistryStat {
+  ecosystem: string
+  metric: string
+  detail: string
+  href: string
+}
+
+interface PublishedArtifact {
+  name: string
+  ecosystem: string
+  version: string
+  description: string
+  href: string
+}
+
+// @group Content : Curated content for the redesigned portfolio
+const proofPoints: ProofPoint[] = [
+  {
+    value: '10+',
+    label: 'years building',
+    detail: 'Software, cloud, AI products, teams, and community',
+  },
+  {
+    value: '20+',
+    label: 'services automated',
+    detail: 'GitHub Actions, Azure DevOps, Docker, Kubernetes, and CI/CD',
+  },
+  {
+    value: '25+',
+    label: 'talks and workshops',
+    detail: 'Azure Functions, gRPC, Kubernetes, Power Automate, and ML.NET',
+  },
+  {
+    value: '5',
+    label: 'cloud ecosystems',
+    detail: 'Azure, AWS, Google Cloud, IBM Cloud, and Salesforce integrations',
+  },
+]
+
+const caseStudies: CaseStudy[] = [
+  {
+    title: 'Tech Lead at Outernet London',
+    period: 'April 2025 - Present',
+    context: 'Building dynamic selection and media integration systems across Node.js, React, Linux, Postgres, Kafka, Redis, SSP, GAM, VAST, and Ventuz.',
+    impact: 'Solo developer delivering application work and DevOps automation through GitHub Actions and Azure.',
+    stack: ['Node.js', 'React', 'Postgres', 'Kafka', 'Redis', 'Microservices', 'Azure'],
+  },
+  {
+    title: 'Co-Founder / Lead Dev at Turboline AI',
+    period: 'September 2023 - Present',
+    context: 'Building Data Query Studio, a natural-language way to query MSSQL, MySQL, Postgres, MongoDB, and Cosmos DB.',
+    impact: 'Developing Azure OpenAI/RAG services, geospatial workflows, APIs, Bicep infrastructure, Docker, Kubernetes, and deployment automation.',
+    stack: ['Azure OpenAI', 'RAG', 'Python', 'TypeScript', 'ASP.NET Core', 'Postgres', 'Docker', 'Kubernetes'],
+  },
+  {
+    title: 'Co-Founder / Software Engineer at Sesio AI',
+    period: 'September 2024 - April 2025',
+    context: 'Developed dynamic AI agents configured through YAML on Azure OpenAI and Azure Functions.',
+    impact: 'Shipped RAG, Document Intelligence, Cosmos DB, Entra, Redis, TypeScript/Python services, and Azure infrastructure automation.',
+    stack: ['Azure OpenAI', 'Document Intelligence', 'Cosmos DB', 'Azure Functions', 'Python', 'TypeScript', 'Bicep'],
+  },
+  {
+    title: 'Software Engineer at AE Live',
+    period: 'December 2022 - May 2024',
+    context: 'Built broadcast graphics, APIs, and cloud-native services for live production workflows.',
+    impact: 'Improved WPF rendering performance by 40% and supported ASP.NET Core APIs handling 100K+ requests per day.',
+    stack: ['C#', 'WPF', 'ASP.NET Core', 'Angular', 'Azure', 'Kafka', 'Redis', 'Kubernetes'],
+  },
+]
+
+const fieldNotes: FieldNote[] = [
+  {
+    title: 'Event-driven development with Service Bus and Functions',
+    meta: 'Reactor Meetup, London',
+    image: '/assets/img/portfolio/LondonReactorMeetup (1).JPG',
+    category: 'Cloud architecture',
+  },
+  {
+    title: 'Creating and managing gRPC apps in Azure',
+    meta: 'Nepal Cloud Summit',
+    image: '/assets/img/portfolio/NCS2022.jpg',
+    category: 'Azure talks',
+  },
+  {
+    title: 'Mentoring teams through product thinking',
+    meta: 'Ideathon 2021',
+    image: '/assets/img/portfolio/Ideathon2021.jpg',
+    category: 'Community',
+  },
+]
+
+const capabilityGroups: CapabilityGroup[] = [
+  {
+    title: 'Application development',
+    items: ['C#', '.NET Core', 'ASP.NET Core', 'Node.js', 'Angular', 'React', 'Next.js', 'WPF'],
+  },
+  {
+    title: 'Cloud, AI and data',
+    items: ['Azure OpenAI', 'RAG', 'Document Intelligence', 'Cosmos DB', 'Postgres', 'Azure Functions', 'Service Bus', 'AWS'],
+  },
+  {
+    title: 'DevOps and delivery',
+    items: ['CI/CD', 'GitHub Actions', 'Azure DevOps', 'Docker', 'Kubernetes', 'Bicep', 'PowerShell', 'Infrastructure as Code'],
+  },
+  {
+    title: 'Leadership and training',
+    items: ['Mentoring', 'Team leadership', '.NET training', 'Cloud computing', 'OOP', 'Network programming'],
+  },
+]
+
+const certifications: Credential[] = [
+  {
+    title: 'Azure AI Fundamentals',
+    issuer: 'Microsoft',
+    meta: 'March 2024',
+    href: 'https://learn.microsoft.com/en-us/users/chandanbhagat/credentials/c6cae068c19caa1a',
+  },
+  {
+    title: 'Principles of Secure Coding',
+    issuer: 'Udemy',
+    meta: 'March 2024',
+    href: 'https://www.udemy.com/certificate/UC-e5cf7457-e545-4703-8b03-ae02ea5da66c/',
+  },
+  {
+    title: 'Develop an ASP.NET Core web app that consumes an API',
+    issuer: 'Microsoft',
+    meta: 'January 2024',
+    href: 'https://learn.microsoft.com/en-us/users/chandanbhagat/credentials/9695ccb3071bf5a2',
+  },
+  {
+    title: 'DevOps Foundations: Microservices',
+    issuer: 'LinkedIn Learning',
+    meta: 'July 2020',
+    href: 'https://www.linkedin.com/learning/certificates/2c3d20fc58a3ff718af08736592a56e9b10e350fb5ae3612ffac03d5f0843e45',
+  },
+  {
+    title: 'MTA: Networking Fundamentals',
+    issuer: 'Microsoft',
+    meta: 'November 2016',
+    href: 'https://www.credly.com/badges/3dba0ee7-1549-4394-bf8b-f281ea6c215a/',
+  },
+]
+
+const teachingEntries: TimelineEntry[] = [
+  {
+    title: '.NET Trainer',
+    meta: 'Broadway Infosys, Kathmandu | February 2020 - October 2022',
+    detail: '.NET Core, OOP in C#, MSSQL, Windows Forms, ASP.NET Core MVC, Entity Framework, Web API, Angular, IIS, and Azure deployment.',
+  },
+  {
+    title: 'Part-time lecturer',
+    meta: 'Orchid College, Aadim College, Academia | 2018 - 2022',
+    detail: 'Network Programming, Computer Networks, Distributed Systems, Numerical Methods, Web Technology, and Cloud Computing.',
+  },
+  {
+    title: '.NET Trainer',
+    meta: 'IT Training Nepal | January 2016 - June 2018',
+    detail: 'Practical, hands-on .NET development training for real-world web and database projects.',
+  },
+]
+
+const educationEntries: TimelineEntry[] = [
+  {
+    title: 'Bachelor in Computer Engineering',
+    meta: 'Institute of Engineering, Pulchowk Campus | January 2011 - July 2015',
+    detail: 'Engineering foundation across software, systems, networks, and applied computing.',
+  },
+  {
+    title: 'High School',
+    meta: 'Bhanu Memorial Higher Secondary School | August 2008 - August 2010',
+    detail: 'Science and mathematics foundation before engineering studies.',
+  },
+]
+
+const profileLinks: ProfileLink[] = [
+  { label: 'NuGet', href: 'https://www.nuget.org/profiles/chandan.bhagat', icon: 'bi bi-box-seam' },
+  { label: 'Open VSX', href: 'https://open-vsx.org/namespace/thechandanbhagat', icon: 'bi bi-puzzle' },
+  { label: 'VS Marketplace', href: 'https://marketplace.visualstudio.com/publishers/thechandanbhagat', icon: 'bi bi-shop' },
+  { label: 'npm', href: 'https://www.npmjs.com/~chandan.bhagat', icon: 'bi bi-box' },
+  { label: 'Docker Hub', href: 'https://hub.docker.com/repository/docker/chandanbhagat/ezkafka-visualizer/general', icon: 'bi bi-boxes' },
+  { label: 'PowerShell', href: 'https://www.powershellgallery.com/profiles/thechandanbhagat', icon: 'bi bi-terminal' },
+  { label: 'GitHub', href: 'https://github.com/thechandanbhagat', icon: 'bi bi-github' },
+  { label: 'LinkedIn', href: 'https://linkedin.com/in/guptac', icon: 'bi bi-linkedin' },
+  { label: 'Utility tools', href: 'https://util.chandanbhagat.com.np', icon: 'bi bi-tools' },
+  { label: 'Math tools', href: 'https://math-tools.chandanbhagat.com.np', icon: 'bi bi-calculator' },
+]
+
+const registryStats: RegistryStat[] = [
+  {
+    ecosystem: 'NuGet',
+    metric: '12 packages',
+    detail: '83K+ downloads across dotnet-essential and Turboline NLQ packages.',
+    href: 'https://www.nuget.org/profiles/chandan.bhagat',
+  },
+  {
+    ecosystem: 'npm',
+    metric: '10 packages',
+    detail: 'CLI tools, MCP servers, SDKs, Kafka tooling, and AI-focused packages.',
+    href: 'https://www.npmjs.com/~chandan.bhagat',
+  },
+  {
+    ecosystem: 'VS Code Marketplace',
+    metric: '5 extensions',
+    detail: 'Group Code, PR Hub, Repo Rig, Overture, and Khukuri Language Support.',
+    href: 'https://marketplace.visualstudio.com/publishers/thechandanbhagat',
+  },
+  {
+    ecosystem: 'Open VSX',
+    metric: '3K+ downloads',
+    detail: 'Group Code and PR Hub published for Open VSX-compatible editors.',
+    href: 'https://open-vsx.org/namespace/thechandanbhagat',
+  },
+  {
+    ecosystem: 'Docker Hub',
+    metric: '20K+ pulls',
+    detail: 'ezkafka-visualizer image for managing and visualizing Kafka clusters.',
+    href: 'https://hub.docker.com/repository/docker/chandanbhagat/ezkafka-visualizer/general',
+  },
+  {
+    ecosystem: 'PowerShell Gallery',
+    metric: '2 modules',
+    detail: '15K+ downloads across UtilModule and SesioWorker modules.',
+    href: 'https://www.powershellgallery.com/profiles/thechandanbhagat',
+  },
+]
+
+const publishedArtifacts: PublishedArtifact[] = [
+  {
+    name: 'dotnet-essential',
+    ecosystem: 'NuGet',
+    version: '7.1.0',
+    description: 'Essential package for .NET projects.',
+    href: 'https://www.nuget.org/packages/dotnet-essential',
+  },
+  {
+    name: 'Turboline.NLQ2SQL.PostgresSQL',
+    ecosystem: 'NuGet',
+    version: '6.2.9',
+    description: 'Natural-language query connector for Turboline AI applications.',
+    href: 'https://www.nuget.org/packages/Turboline.NLQ2SQL.PostgresSQL',
+  },
+  {
+    name: 'ezpm2gui',
+    ecosystem: 'npm',
+    version: '1.11.1',
+    description: 'Modern web-based GUI for the PM2 process manager.',
+    href: 'https://www.npmjs.com/package/ezpm2gui',
+  },
+  {
+    name: 'cv-forge',
+    ecosystem: 'npm',
+    version: '1.0.3',
+    description: 'MCP server for generating ATS-friendly CVs tailored to job descriptions.',
+    href: 'https://www.npmjs.com/package/cv-forge',
+  },
+  {
+    name: 'ezkafka-visualizer',
+    ecosystem: 'Docker Hub',
+    version: '20K+ pulls',
+    description: 'Web app and container image for managing Kafka clusters.',
+    href: 'https://hub.docker.com/repository/docker/chandanbhagat/ezkafka-visualizer/general',
+  },
+  {
+    name: 'Group Code',
+    ecosystem: 'VS Code / Open VSX',
+    version: '1.8.0',
+    description: 'Navigate and organize codebases by functionality across file types.',
+    href: 'https://marketplace.visualstudio.com/items?itemName=thechandanbhagat.groupcode',
+  },
+  {
+    name: 'PR Hub',
+    ecosystem: 'VS Code / Open VSX',
+    version: '1.1.0',
+    description: 'AI-powered pull request reviews across GitHub, Azure DevOps, GitLab, and Bitbucket.',
+    href: 'https://marketplace.visualstudio.com/items?itemName=thechandanbhagat.pr-hub',
+  },
+  {
+    name: 'UtilModule',
+    ecosystem: 'PowerShell Gallery',
+    version: '2.0.1',
+    description: 'PowerShell utility module with many functions.',
+    href: 'https://www.powershellgallery.com/packages/UtilModule/2.0.1',
+  },
+]
+
+const bootLines = [
+  'mount /dev/azure /systems',
+  'load .NET + Node.js runtimes',
+  'wire Azure OpenAI agents',
+  'start kubernetes.service',
+  'ship useful software',
+]
+
+// @group PortfolioDossier : New root portfolio page
+export default function PortfolioDossier() {
+  const progressRef = useRef<HTMLDivElement>(null)
+
+  // @group Motion : Scroll-reveal, stat count-up, and read-progress wiring
+  useEffect(() => {
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    const revealEls = Array.from(document.querySelectorAll<HTMLElement>('.reveal'))
+    const countEls = Array.from(document.querySelectorAll<HTMLElement>('[data-count]'))
+
+    if (reducedMotion) {
+      revealEls.forEach((el) => el.classList.add('is-visible'))
+      return
+    }
+
+    const revealObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return
+          entry.target.classList.add('is-visible')
+          revealObserver.unobserve(entry.target)
+        })
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -8% 0px' }
+    )
+    revealEls.forEach((el) => revealObserver.observe(el))
+
+    const countObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return
+          const el = entry.target as HTMLElement
+          countObserver.unobserve(el)
+          const raw = el.dataset.count ?? ''
+          const target = parseInt(raw, 10)
+          const suffix = raw.replace(/[0-9]/g, '')
+          if (Number.isNaN(target)) return
+          const duration = 1400
+          const start = performance.now()
+          const tick = (now: number) => {
+            const progress = Math.min((now - start) / duration, 1)
+            const eased = 1 - Math.pow(1 - progress, 3)
+            el.textContent = `${Math.round(eased * target)}${suffix}`
+            if (progress < 1) requestAnimationFrame(tick)
+          }
+          requestAnimationFrame(tick)
+        })
+      },
+      { threshold: 0.6 }
+    )
+    countEls.forEach((el) => {
+      const raw = el.dataset.count ?? ''
+      el.textContent = `0${raw.replace(/[0-9]/g, '')}`
+      countObserver.observe(el)
+    })
+
+    return () => {
+      revealObserver.disconnect()
+      countObserver.disconnect()
+    }
+  }, [])
+
+  useEffect(() => {
+    const onScroll = () => {
+      const bar = progressRef.current
+      if (!bar) return
+      const doc = document.documentElement
+      const scrollable = doc.scrollHeight - doc.clientHeight
+      const ratio = scrollable > 0 ? doc.scrollTop / scrollable : 0
+      bar.style.transform = `scaleX(${Math.min(Math.max(ratio, 0), 1)})`
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [])
+
+  return (
+    <main className="dossier-shell">
+      <div className="dossier-progress" ref={progressRef} aria-hidden="true" />
+      <section className="dossier-hero" aria-labelledby="dossier-title">
+        <nav className="dossier-nav" aria-label="Portfolio navigation">
+          <a className="dossier-brand" href="/">
+            <span className="dossier-brand-mark">CB</span>
+            <span>Chandan Gupta Bhagat</span>
+          </a>
+          <div className="dossier-nav-links">
+            <a href="#work">Work</a>
+            <a href="#tools">Tools</a>
+            <a href="#speaking">Speaking</a>
+            <a href="#contact">Contact</a>
+            <a href="/terminal">Terminal</a>
+          </div>
+        </nav>
+
+        <div className="dossier-hero-content">
+          <p className="dossier-kicker">London / Kent software engineer, cloud architect, trainer</p>
+          <h1 id="dossier-title">Chandan Gupta Bhagat</h1>
+          <p className="dossier-manifesto">Cloud systems, AI products, calm delivery.</p>
+          <p className="dossier-hero-copy">
+            Senior engineer across C#, Azure, Node.js, React, and AI systems, with hands-on
+            experience in web, desktop, cloud, data, DevOps, training, and mentorship.
+          </p>
+          <div className="dossier-actions" aria-label="Primary actions">
+            <a href="mailto:chandan.bhagat@outlook.com" className="dossier-action primary">
+              <i className="bi bi-envelope" aria-hidden="true"></i>
+              Start a conversation
+            </a>
+            <a href="https://linkedin.com/in/guptac" target="_blank" rel="noreferrer" className="dossier-action">
+              <i className="bi bi-linkedin" aria-hidden="true"></i>
+              LinkedIn
+            </a>
+            <a href="https://github.com/thechandanbhagat" target="_blank" rel="noreferrer" className="dossier-action icon-only" aria-label="GitHub">
+              <i className="bi bi-github" aria-hidden="true"></i>
+            </a>
+          </div>
+        </div>
+
+        <div className="dossier-console" aria-label="Portfolio boot sequence">
+          <div className="dossier-console-top">
+            <span></span>
+            <span></span>
+            <span></span>
+            <strong>portfolio.deploy</strong>
+          </div>
+          <div className="dossier-console-body">
+            {bootLines.map((line) => (
+              <p key={line}>
+                <span>$</span> {line}
+              </p>
+            ))}
+            <p className="dossier-console-ready">
+              <span>ok</span> available for senior engineering, cloud architecture, AI product work, and technical leadership
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="dossier-proof" aria-label="Proof points">
+        {proofPoints.map((point, index) => (
+          <article className="dossier-proof-item reveal" style={stagger(index)} key={point.label}>
+            <strong data-count={point.value}>{point.value}</strong>
+            <span>{point.label}</span>
+            <p>{point.detail}</p>
+          </article>
+        ))}
+      </section>
+
+      <section id="work" className="dossier-section dossier-split">
+        <div className="dossier-section-heading reveal">
+          <p>Delivery record</p>
+          <h2>Current product work.</h2>
+        </div>
+        <div className="dossier-case-list">
+          {caseStudies.map((study, index) => (
+            <article className="dossier-case reveal" style={stagger(index)} key={study.title}>
+              <div>
+                <span className="dossier-case-period">{study.period}</span>
+                <h3>{study.title}</h3>
+                <p>{study.context}</p>
+              </div>
+              <strong>{study.impact}</strong>
+              <div className="dossier-tags">
+                {study.stack.map((tag) => (
+                  <span key={tag}>{tag}</span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section id="speaking" className="dossier-section">
+        <div className="dossier-section-heading compact reveal">
+          <p>Field notes</p>
+          <h2>Talks, workshops, and community work.</h2>
+        </div>
+        <div className="dossier-field-grid">
+          {fieldNotes.map((note, index) => (
+            <article className="dossier-field-note reveal" style={stagger(index)} key={note.title}>
+              <img src={note.image} alt={note.title} />
+              <div>
+                <span>{note.category}</span>
+                <h3>{note.title}</h3>
+                <p>{note.meta}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="dossier-section dossier-capabilities">
+        <div className="dossier-section-heading compact reveal">
+          <p>Operating range</p>
+          <h2>The toolkit I reach for most often.</h2>
+        </div>
+        <div className="dossier-capability-grid">
+          {capabilityGroups.map((group, index) => (
+            <article className="dossier-capability reveal" style={stagger(index)} key={group.title}>
+              <h3>{group.title}</h3>
+              <ul>
+                {group.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section id="tools" className="dossier-section dossier-tools">
+        <div className="dossier-section-heading compact reveal">
+          <p>Published tools</p>
+          <h2>Packages, extensions, modules, and containers.</h2>
+        </div>
+        <div className="dossier-registry-grid">
+          {registryStats.map((stat, index) => (
+            <a href={stat.href} target="_blank" rel="noreferrer" className="dossier-registry-card reveal" style={stagger(index)} key={stat.ecosystem}>
+              <span>{stat.ecosystem}</span>
+              <strong>{stat.metric}</strong>
+              <p>{stat.detail}</p>
+            </a>
+          ))}
+        </div>
+        <div className="dossier-artifact-grid">
+          {publishedArtifacts.map((artifact, index) => (
+            <a href={artifact.href} target="_blank" rel="noreferrer" className="dossier-artifact reveal" style={stagger(index)} key={`${artifact.ecosystem}-${artifact.name}`}>
+              <span>{artifact.ecosystem} | {artifact.version}</span>
+              <strong>{artifact.name}</strong>
+              <p>{artifact.description}</p>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className="dossier-section dossier-credentials">
+        <div className="dossier-section-heading compact reveal">
+          <p>Credentials and teaching</p>
+          <h2>Built in public, taught in classrooms, certified in practice.</h2>
+        </div>
+        <div className="dossier-credential-layout">
+          <article className="dossier-credential-panel reveal" style={stagger(0)}>
+            <h3>Selected certifications</h3>
+            <div className="dossier-credential-list">
+              {certifications.map((credential) => {
+                const content = (
+                  <>
+                    <strong>{credential.title}</strong>
+                    <span>{credential.issuer} | {credential.meta}</span>
+                  </>
+                )
+
+                return credential.href ? (
+                  <a href={credential.href} target="_blank" rel="noreferrer" key={credential.title}>
+                    {content}
+                  </a>
+                ) : (
+                  <div key={credential.title}>{content}</div>
+                )
+              })}
+            </div>
+          </article>
+
+          <article className="dossier-credential-panel reveal" style={stagger(1)}>
+            <h3>Training and mentoring</h3>
+            <div className="dossier-timeline">
+              {teachingEntries.map((entry) => (
+                <div key={entry.title + entry.meta}>
+                  <strong>{entry.title}</strong>
+                  <span>{entry.meta}</span>
+                  <p>{entry.detail}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+
+          <article className="dossier-credential-panel reveal" style={stagger(2)}>
+            <h3>Education</h3>
+            <div className="dossier-timeline">
+              {educationEntries.map((entry) => (
+                <div key={entry.title}>
+                  <strong>{entry.title}</strong>
+                  <span>{entry.meta}</span>
+                  <p>{entry.detail}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="contact" className="dossier-contact">
+        <div className="reveal">
+          <p>Current signal</p>
+          <h2>Available for senior engineering, AI product, and cloud architecture roles.</h2>
+        </div>
+        <div className="dossier-contact-actions reveal" style={stagger(1)}>
+          <a href="mailto:chandan.bhagat@outlook.com">
+            <i className="bi bi-envelope" aria-hidden="true"></i>
+            chandan.bhagat@outlook.com
+          </a>
+          <a href="tel:+447818620731">
+            <i className="bi bi-telephone" aria-hidden="true"></i>
+            +44 7818 620731
+          </a>
+        </div>
+        <div className="dossier-profile-grid" aria-label="Public profiles and tools">
+          {profileLinks.map((link) => (
+            <a href={link.href} target="_blank" rel="noreferrer" key={link.label}>
+              <i className={link.icon} aria-hidden="true"></i>
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## What

Adds a new `PortfolioDossier` page as the root route (`/`) and moves the existing terminal experience to `/terminal`. The page is built with a "dossier" layout (hero + boot console, proof stats, delivery record, field notes, capabilities, published tools, credentials, contact) and ships with a layer of tasteful, dependency-free motion design.

## Motion design

All motion is hand-rolled (no animation libraries) and lives in [`PortfolioDossier.tsx`](src/pages/PortfolioDossier.tsx) + [`PortfolioDossier.css`](src/pages/PortfolioDossier.css):

- **Entrance choreography** — hero kicker → headline → manifesto → copy → actions rise/fade in with stagger; the terminal console slides up and types its boot lines in sequence, ending with a blinking caret.
- **Scroll reveals** — sections and cards fade-up on enter via `IntersectionObserver`, with per-item stagger delays.
- **Stat count-up** — the four proof numbers ease from 0 → target when scrolled into view, suffixes preserved.
- **Read-progress bar** — thin fixed bar at the top tracks scroll depth.
- **Hover micro-interactions** — added real transitions to previously instant hover states, plus lift-on-hover for cards, brand-mark tilt, and capability pills.

## Why

The previous root route dropped visitors straight into the terminal view. The dossier page is a more conventional, recruiter-friendly landing experience while keeping the terminal available at `/terminal`.

## Accessibility

Every animation is wrapped in `@media (prefers-reduced-motion: no-preference)`, and the JS detects reduced-motion to immediately show all content and skip the count-up — motion-sensitive users get the static page with no flashes.

## Notes for reviewer

- Route change: `/` now renders `PortfolioDossier`; `TerminalPortfolio` moved to `/terminal` ([`App.tsx`](src/App.tsx)).
- `.groupcode/*` changes are the Group Code extension index regenerated for the new file groups.
- `npm run build` passes.